### PR TITLE
add method to start new span from parent span

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ protocol.
 -spec span_start(info(), integer(), integer()) -> span().
 ```
 
+Start span with name and parent span. trace_id and parent span id are
+extracted from the parent.
+
+```erlang
+-spec span_start(info(), ParentSpan :: span()) -> span().
+```
+
 Add a tag to the previously started span.
 ```erlang
 -spec span_tag(span(), info(), info()) -> span().

--- a/src/otter.erl
+++ b/src/otter.erl
@@ -34,8 +34,13 @@ span_start(Name) ->
     otter_span:fstart(Name).
 
 -spec span_start(info(), integer()) -> span().
-span_start(Name, TraceId) ->
-    otter_span:fstart(Name, TraceId).
+span_start(Name, TraceId)
+  when is_integer(TraceId) ->
+    otter_span:fstart(Name, TraceId);
+span_start(Name, ParentSpan)
+  when is_record(ParentSpan, span) ->
+    {TraceId, ParentId} = otter_span:fget_ids(ParentSpan),
+    otter_span:fstart(Name, TraceId, ParentId).
 
 -spec span_start(info(), integer(), integer()) -> span().
 span_start(Name, TraceId, ParentId) ->


### PR DESCRIPTION
The span inherits the trace_id from the parent and the
parent span id is setup automatically.