### PR TITLE
add additional converters for data types in info

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The following type specifications are in otter.hrl
 
 ```erlang
 -type time_us() :: integer().           % timestamp in microseconds
--type info()    :: binary() | list() | atom() | integer().
+-type info()    :: binary() | iolist() | atom() | integer().
 -type ip4()     :: {integer(), integer(), integer(), integer()}.
 -type service() :: binary() | list() | default | {binary() | list(), ip4(), integer()}.
 -type trace_id():: integer().
@@ -287,8 +287,8 @@ example :
 
 A note on the tag key/value and log types: the Zipkin interface requires
 string types. The Zipkin connector module (otter_conn_zipkin.erl) attempts
-to convert: integer, atom, list types to binary. This allows using these
-data types too as keys, values and logs, however any other "non-obvious"
+to convert: integer, atom, and iolist types to binary. This allows using
+these data types too as keys, values and logs, however any other "non-obvious"
 types would still need conversion (or simply can not be used). The impact
 of having an incompatible type in the tag keys, values and logs will likely
 crash the encoding/sending function in the Zipkin connector module resulting

--- a/README.md
+++ b/README.md
@@ -287,12 +287,10 @@ example :
 
 A note on the tag key/value and log types: the Zipkin interface requires
 string types. The Zipkin connector module (otter_conn_zipkin.erl) attempts
-to convert: integer, atom, and iolist types to binary. This allows using
-these data types too as keys, values and logs, however any other "non-obvious"
-types would still need conversion (or simply can not be used). The impact
-of having an incompatible type in the tag keys, values and logs will likely
-crash the encoding/sending function in the Zipkin connector module resulting
-the loss of the particular batch of spans.
+to convert: integer, atom, and iolist types to binary. Unknown data types
+(e.g. record, tuples, or maps) are converted using the "~p" io:fwrite formating
+control character. The resulting string might be hard to read for non-Erlang
+people, but it is still better than loosing the information completely.
 
 Adding service information to tags and logs means that otter adds a host
 structure to each of these elements. The extra optional service parameter

--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ to convert: integer, atom, and iolist types to binary. Unknown data types
 control character. The resulting string might be hard to read for non-Erlang
 people, but it is still better than loosing the information completely.
 
+If the generation of log values is complex or computational expensive, a
+arity zero fun can be passed as info. The function is executed in the
+connector module and thereby after span_end has been called.
+
 Adding service information to tags and logs means that otter adds a host
 structure to each of these elements. The extra optional service parameter
 in the relevant API calls can have 3 formats.

--- a/src/otter.hrl
+++ b/src/otter.hrl
@@ -1,5 +1,5 @@
 -type time_us() :: integer().           % timestamp in microseconds
--type info()    :: binary() | list() | atom() | integer().
+-type info()    :: binary() | iolist() | atom() | integer().
 -type ip4()     :: {integer(), integer(), integer(), integer()}.
 -type service() :: binary() | list() | default | {binary() | list(), ip4(), integer()}.
 -type trace_id():: integer().

--- a/src/otter_lib.erl
+++ b/src/otter_lib.erl
@@ -45,5 +45,7 @@ to_bin(List) when is_list(List) ->
     unicode:characters_to_binary(List);
 to_bin(Binary) when is_binary(Binary) ->
     Binary;
+to_bin(Fun) when is_function(Fun, 0) ->
+    to_bin(Fun());
 to_bin(Value) ->
     unicode:characters_to_binary(io_lib:format("~1024p", [Value])).

--- a/src/otter_lib.erl
+++ b/src/otter_lib.erl
@@ -40,7 +40,7 @@ id() ->
 to_bin(Int) when is_integer(Int)->
     integer_to_binary(Int);
 to_bin(Atom) when is_atom(Atom) ->
-    list_to_binary(atom_to_list(Atom));
+    atom_to_binary(Atom, 'utf8');
 to_bin(List) when is_list(List) ->
     unicode:characters_to_binary(List);
 to_bin(Binary) when is_binary(Binary) ->

--- a/src/otter_lib.erl
+++ b/src/otter_lib.erl
@@ -41,10 +41,7 @@ to_bin(Int) when is_integer(Int)->
     integer_to_binary(Int);
 to_bin(Atom) when is_atom(Atom) ->
     list_to_binary(atom_to_list(Atom));
-% Well, this is not so obvious so I assume the warnings in documentation
-% work and folks will send character listst. Otherwise it should crash
-% somewhere.
 to_bin(List) when is_list(List) ->
-    list_to_binary(List);
+    unicode:characters_to_binary(List);
 to_bin(Binary) when is_binary(Binary) ->
     Binary.

--- a/src/otter_lib.erl
+++ b/src/otter_lib.erl
@@ -44,4 +44,6 @@ to_bin(Atom) when is_atom(Atom) ->
 to_bin(List) when is_list(List) ->
     unicode:characters_to_binary(List);
 to_bin(Binary) when is_binary(Binary) ->
-    Binary.
+    Binary;
+to_bin(Value) ->
+    unicode:characters_to_binary(io_lib:format("~1024p", [Value])).

--- a/test/otter_SUITE.erl
+++ b/test/otter_SUITE.erl
@@ -32,7 +32,8 @@ ftest(_Config) ->
     S6 = otter:span_log(S5, 'this is a atom'),
     S7 = otter:span_log(S6, io_lib:format("int: ~w, float: ~f, hex: ~.16B, Span: ~p",
 					  [1, 1.0, 1, S6])),
-    otter:span_end(S7),
+    S8 = otter:span_log(S7, S7),
+    otter:span_end(S8),
     timer:sleep(200),
     [_] = ets:tab2list(test_span_collector).
 

--- a/test/otter_SUITE.erl
+++ b/test/otter_SUITE.erl
@@ -13,6 +13,7 @@ ptest(_Config) ->
     ets:new(test_span_collector, [named_table, public, {keypos, 2}]),
     otter:span_pstart("test_span"),
     otter:span_plog("started"),
+    otter:span_plog("α =:= ω"),
     otter:span_ptag("result", "ok"),
     otter:span_pend(),
     timer:sleep(200),
@@ -26,7 +27,12 @@ ftest(_Config) ->
     S1 = otter:span_start("test_span"),
     S2 = otter:span_log(S1, "started"),
     S3 = otter:span_tag(S2, "result", "ok"),
-    otter:span_end(S3),
+    S4 = otter:span_log(S3, "α =:= ω"),
+    S5 = otter:span_log(S4, 123456),
+    S6 = otter:span_log(S5, 'this is a atom'),
+    S7 = otter:span_log(S6, io_lib:format("int: ~w, float: ~f, hex: ~.16B, Span: ~p",
+					  [1, 1.0, 1, S6])),
+    otter:span_end(S7),
     timer:sleep(200),
     [_] = ets:tab2list(test_span_collector).
 

--- a/test/otter_SUITE.erl
+++ b/test/otter_SUITE.erl
@@ -33,7 +33,8 @@ ftest(_Config) ->
     S7 = otter:span_log(S6, io_lib:format("int: ~w, float: ~f, hex: ~.16B, Span: ~p",
 					  [1, 1.0, 1, S6])),
     S8 = otter:span_log(S7, S7),
-    otter:span_end(S8),
+    S9 = otter:span_log(S8, fun() -> "result of function" end),
+    otter:span_end(S9),
     timer:sleep(200),
     [_] = ets:tab2list(test_span_collector).
 


### PR DESCRIPTION
This add or fixes formaters for:
 * UTF8 string
 * iolists (e.g. the result of io_lib:format/2 call)
 * catch all for unknown data types
 * arity zero functions for delay log message generation and formating