### PR TITLE
specify version of otter_lib in rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,9 @@
 {erl_opts, [debug_info]}.
+
 {deps, [
-    otter_lib
+    {otter_lib, "0.1.1"}
 ]}.
+
 {xref_checks,[undefined_function_calls,undefined_functions,locals_not_used,
               deprecated_function_calls,
               deprecated_functions]}.


### PR DESCRIPTION
As without it build of releaes is broken with Elixir 1.12 when otter is used as a dependency